### PR TITLE
Feature/web ui url settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # HorribleSubs batcher
+
 WebExtension to create naive batch downloads before official HorribleSubs batches exist.
 
 **Warning**: This extension was created for qBittorrent's WebUI, it currently does not work with other BitTorrent clients. I will update it to work with BitTorrent and uTorrent Soon™.
@@ -7,25 +8,25 @@ WebExtension to create naive batch downloads before official HorribleSubs batche
 
 Feel free to request or contribute any features.
 
-
 ## How to use
+
 1. Install and open qBittorrent
 2. Open Preferences > WebUI
 3. Check the "Web User Interface (Remote control)" box and "Bypass authentication for clients on localhost" below it
 4. Download the extension from "Releases" and install it on your browser. Drag the file onto it or something.
-5. Open https://horriblesubs.info/shows/<your-anime-here\> on your browser.
+5. Open `https://horriblesubs.info/shows/<your-anime-here>` on your browser.
 6. Choose a resolution from the dropdown list below the episode filter text box.
 7. Click the Download button.
 
 Remember to open qBittorrent before you try to download anything, otherwise it won't work. I will try to implement some kind of alert if possible.
 
-
 ## How it works
+
 * It gets a list of all magnet links that are visible on the page, with the selected resolution
 * Sends the list to your qBittorrent WebUI `/download` endpoint. It currently assumes no authentication is needed on localhost.
 
+## TODO
 
-## TODO:
 * Add BitTorrent and uTorrent compatibility
 * Add images to README
 * Check if alert can be implemented to popup if your qBittorrent client is not open

--- a/batcher.js
+++ b/batcher.js
@@ -34,7 +34,11 @@ async function downloadVisibleLinks(res) {
 
     if (!DRY_RUN) {
         let settings = await getSettings();
-        let downloadEndpoint = `http://${settings.host}:${settings.port}/api/v2/torrents/add`;
+        let torrentAddPath = "api/v2/torrents/add";
+        if (settings.apiVersion == 1) {
+            torrentAddPath = "command/download";
+        }
+        let downloadEndpoint = `http://${settings.host}:${settings.port}/${torrentAddPath}`;
 
         let magnetURLs = Array.from(magnets[res], a => a.href).reverse().join("\n");
         post(downloadEndpoint, { urls: magnetURLs });

--- a/batcher.js
+++ b/batcher.js
@@ -7,8 +7,8 @@ function post(path, params, callback) {
 
     xhr.open("POST", path, true);
 
-    xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4)
+    xhr.onreadystatechange = function () {
+        if (callback && xhr.readyState == 4)
             callback(xhr);
     };
 
@@ -24,7 +24,8 @@ function downloadVisibleLinks(res) {
     magnets[res] = document.querySelectorAll("div[class$='" + res + "p'] a[title='Magnet Link']");
 
     if (!DRY_RUN) {
-        magnets[res].forEach(magnet => post(downloadPath, {"urls": magnet.href}, (xhr) => console.log(xhr.response)));
+        let magnetURLs = Array.from(magnets[res], a => a.href).reverse().join("\n");
+        post(downloadPath, { urls: magnetURLs });
     } else {
         console.log("Magnets found for " + res + "p: " + magnets[res].length);
     }

--- a/batcher.js
+++ b/batcher.js
@@ -1,7 +1,8 @@
-var DRY_RUN = false;
-var resList = [480, 720, 1080];
-var downloadPath = "http://localhost:8080/api/v2/torrents/add";
+const DRY_RUN = false;
+const resolutions = [360, 480, 720, 1080];
 
+// Uses XHR because for some reason it doesn't send an Origin header
+// while fetch() sends 'Origin: null', which triggers CSRF protection
 function post(path, params, callback) {
     let xhr = new XMLHttpRequest();
 
@@ -19,13 +20,24 @@ function post(path, params, callback) {
     xhr.send(formData);
 }
 
-function downloadVisibleLinks(res) {
+async function getSettings() {
+    let defaultsURL = browser.runtime.getURL("options/defaults.json");
+    let response = await fetch(defaultsURL, { mode: "no-cors" });
+    let defaults = await response.json();
+
+    return browser.storage.sync.get(defaults);
+}
+
+async function downloadVisibleLinks(res) {
     let magnets = {};
     magnets[res] = document.querySelectorAll("div[class$='" + res + "p'] a[title='Magnet Link']");
 
     if (!DRY_RUN) {
+        let settings = await getSettings();
+        let downloadEndpoint = `http://${settings.host}:${settings.port}/api/v2/torrents/add`;
+
         let magnetURLs = Array.from(magnets[res], a => a.href).reverse().join("\n");
-        post(downloadPath, { urls: magnetURLs });
+        post(downloadEndpoint, { urls: magnetURLs });
     } else {
         console.log("Magnets found for " + res + "p: " + magnets[res].length);
     }
@@ -44,10 +56,10 @@ function injectElements() {
     div.append(wrapper);
 
     let select = document.createElement("select");
-    for (let i = 0; i < resList.length; i++) {
+    for (let i = 0; i < resolutions.length; i++) {
         let option = document.createElement("option");
-        option.value = resList[i];
-        option.text = resList[i] + "p";
+        option.value = resolutions[i];
+        option.text = resolutions[i] + "p";
         select.append(option);
     }
     wrapper.append(select);

--- a/batcher.js
+++ b/batcher.js
@@ -1,6 +1,6 @@
 var DRY_RUN = false;
 var resList = [480, 720, 1080];
-var downloadPath = "http://localhost:8080/command/download";
+var downloadPath = "http://localhost:8080/api/v2/torrents/add";
 
 function post(path, params, callback) {
     let xhr = new XMLHttpRequest();

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,19 @@
             ]
         }
     ],
+    "options_ui": {
+        "page": "options/options.html"
+    },
+    "web_accessible_resources": [
+        "options/defaults.json"
+    ],
     "permissions": [
-        "http://localhost/*"
-    ]
+        "http://localhost/*",
+        "storage"
+    ],
+    "applications": {
+        "gecko": {
+            "id": "hs-batcher@jlledo.addons.mozilla.org"
+        }
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,19 @@
 {
-	"manifest_version": 2,
-	"name": "HS Batcher",
-	"version": "1.0.1",
-
-	"description": "Create naive batch downloads before official HorribleSubs batches exist.",
-
-	"content_scripts": [
-		{
-			"matches": ["https://horriblesubs.info/shows/*"],
-			"js": ["batcher.js"]
-		}
-	],
-	"permissions": ["http://localhost/*"]
+    "manifest_version": 2,
+    "name": "HS Batcher",
+    "version": "1.0.1",
+    "description": "Create naive batch downloads before official HorribleSubs batches exist.",
+    "content_scripts": [
+        {
+            "matches": [
+                "https://horriblesubs.info/shows/*"
+            ],
+            "js": [
+                "batcher.js"
+            ]
+        }
+    ],
+    "permissions": [
+        "http://localhost/*"
+    ]
 }

--- a/options/defaults.json
+++ b/options/defaults.json
@@ -1,0 +1,4 @@
+{
+    "host": "localhost",
+    "port": 8080
+}

--- a/options/defaults.json
+++ b/options/defaults.json
@@ -1,4 +1,5 @@
 {
+    "apiVersion": 2,
     "host": "localhost",
     "port": 8080
 }

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,15 @@
+body {
+    padding: 1rem
+}
+
+div {
+    margin: 0.5rem
+}
+
+#host {
+    width: 16rem
+}
+
+#port {
+    width: 6rem
+}

--- a/options/options.html
+++ b/options/options.html
@@ -11,6 +11,14 @@
 
     <form>
         <div>
+            <h2>qBittorrent Version</h2>
+            <input type="radio" id="apiVersion1" name="apiVersion" value="1">
+            <label for="apiVersion1">v3.3.1-v4.0.4</label>
+
+            <input type="radio" id="apiVersion2" name="apiVersion" value="2">
+            <label for="apiVersion2">v4.1+</label>
+        </div>
+        <div>
             <h2>Web API</h2>
             <label>Host <input type="text" id="host" name="host"></label>
             <label>Port <input type="number" id="port" name="port" min="1024" max="65535"></label>

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <link href="options.css" rel="stylesheet">
+</head>
+
+<body>
+    <h1>HorribleSubs Batcher Settings</h1>
+
+    <form>
+        <div>
+            <h2>Web API</h2>
+            <label>Host <input type="text" id="host" name="host"></label>
+            <label>Port <input type="number" id="port" name="port" min="1024" max="65535"></label>
+        </div>
+        <div id="status"></div>
+        <button type="submit">Save</button>
+    </form>
+
+    <script src="options.js"></script>
+</body>
+
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,7 @@
 function saveOptions(e) {
     let formData = new FormData(e.srcElement);
     browser.storage.sync.set({
+        apiVersion: formData.get("apiVersion"),
         host: formData.get("host"),
         port: formData.get("port"),
     });
@@ -13,6 +14,7 @@ async function restoreOptions() {
     let defaults = await response.json();
 
     let settings = await browser.storage.sync.get(defaults);
+    document.getElementById(`apiVersion${settings.apiVersion}`).checked = true;
     document.getElementById("host").value = settings.host;
     document.getElementById("port").value = settings.port;
 }

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,21 @@
+function saveOptions(e) {
+    let formData = new FormData(e.srcElement);
+    browser.storage.sync.set({
+        host: formData.get("host"),
+        port: formData.get("port"),
+    });
+    e.preventDefault();
+}
+
+async function restoreOptions() {
+    let defaultsURL = browser.runtime.getURL("options/defaults.json");
+    let response = await fetch(defaultsURL, { mode: "no-cors" });
+    let defaults = await response.json();
+
+    let settings = await browser.storage.sync.get(defaults);
+    document.getElementById("host").value = settings.host;
+    document.getElementById("port").value = settings.port;
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.querySelector("form").addEventListener("submit", saveOptions);


### PR DESCRIPTION
Adds a setting for customising the Web API URL to which the extension posts torrent add requests, and a setting for supporting the 2 latest Web API versions.

I also sneaked in a change to reverse the torrent download order, as requested in https://github.com/jlledo/hs-batcher/issues/1#issuecomment-601778883.

Closes #1.