### PR TITLE
Fix/remote server requests

### DIFF
--- a/batcher.js
+++ b/batcher.js
@@ -1,3 +1,4 @@
+const DEBUG = false;
 const DRY_RUN = false;
 const resolutions = [360, 480, 720, 1080];
 
@@ -41,7 +42,18 @@ async function downloadVisibleLinks(res) {
         let downloadEndpoint = `http://${settings.host}:${settings.port}/${torrentAddPath}`;
 
         let magnetURLs = Array.from(magnets[res], a => a.href).reverse().join("\n");
-        post(downloadEndpoint, { urls: magnetURLs });
+
+        let callback = null;
+        if (DEBUG) {
+            callback = function (xhr) {
+                console.log(
+                    `Response from '${xhr.responseURL}':\n` +
+                    `Status: ${xhr.status}\n` +
+                    `Response: '${xhr.responseText}'`
+                );
+            }
+        }
+        post(downloadEndpoint, { urls: magnetURLs }, callback);
     } else {
         console.log("Magnets found for " + res + "p: " + magnets[res].length);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
         "options/defaults.json"
     ],
     "permissions": [
-        "http://localhost/*",
+        "http://*/*",
         "storage"
     ],
     "applications": {


### PR DESCRIPTION
Fixes download requests to remote servers. Adds a bit of debug logging and expands permissions to allow remote requests.

Tested on Firefox 74 on macOS 10.15.3, making requests to a qBittorrent v4.2.1 client on a Fedora 31 workstation on LAN.

Closes #1.